### PR TITLE
Pass request_context to _new_pool

### DIFF
--- a/adapters.py
+++ b/adapters.py
@@ -111,7 +111,7 @@ class ForcedIPHTTPSPoolManager(PoolManager):
         self.dest_ip = kwargs.pop('dest_ip', None)
         super(ForcedIPHTTPSPoolManager, self).__init__(*args, **kwargs)
 
-    def _new_pool(self, scheme, host, port):
+    def _new_pool(self, scheme, host, port, request_context=None):
             kwargs = self.connection_pool_kw
             assert scheme == 'https'
             kwargs['dest_ip'] = self.dest_ip


### PR DESCRIPTION
I got an error while trying to use the adapter with recent python and urllib3. A solution seems to be what's suggested in https://github.com/requests/requests/issues/4010#issuecomment-300352930