### PR TITLE
Resolve DeprecationWarning: distutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+forcediphttpsadapter.egg-info/*

--- a/forcediphttpsadapter/adapters.py
+++ b/forcediphttpsadapter/adapters.py
@@ -68,7 +68,7 @@ response = session.get(
 # if it's <2.7.9 decide to use the old "http://$IP/ technique. If Python is
 # >2.7.9 and the adapter doesn't work, unfortunately, there's nothing that can
 # be done :(
-from distutils.version import StrictVersion
+from packaging.version import Version
 from socket import error as SocketError, timeout as SocketTimeout
 
 import requests
@@ -89,7 +89,7 @@ except ImportError:
 # Requests older than 2.4.0's VerifiedHHTPSConnection is broken and doesn't
 # properly use _new_conn. On these versions, use UnverifiedHTTPSConnection
 # instead.
-if StrictVersion(requests.__version__) < StrictVersion('2.4.0'):
+if Version(requests.__version__) < Version('2.4.0'):
     from requests.packages.urllib3.connection import (
         UnverifiedHTTPSConnection as HTTPSConnection
     )

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ connecting via SSL to a web service without running into SNI trouble.
 from setuptools import setup, find_packages
 
 
-PACKAGE_NAME = 'forcediphttpsadapter'
-PACKAGE_VERSION = '1.0.2'
-AUTHOR = 'Roadmaster'
-EMAIL = 'daniel@tomechangosubanana.com'
-URL = 'https://github.com/Roadmaster/forcediphttpsadapter'
+PACKAGE_NAME = "forcediphttpsadapter"
+PACKAGE_VERSION = "1.0.2"
+AUTHOR = "Roadmaster"
+EMAIL = "daniel@tomechangosubanana.com"
+URL = "https://github.com/Roadmaster/forcediphttpsadapter"
 
 
 setup(
@@ -24,19 +24,15 @@ setup(
     url=URL,
     # classifiers=CLASSIFIERS,
     # platforms=PLATFORMS,
-    provides=['adapters'],
-    install_requires=['requests'],
+    provides=["adapters"],
+    install_requires=["packaging", "requests"],
     # dependency_links=dependency_links,
-
     packages=find_packages(),
     # include_package_data=True,
     # package_data=package_data,
-
-    download_url='{}/archive/master.zip'.format(URL),
+    download_url="{}/archive/master.zip".format(URL),
     # keywords=KEYWORDS,
     # scripts=scripts,
-
     # entry_points={},
-
     zip_safe=False,
 )


### PR DESCRIPTION
distutils will be deprecated in python 3.12 [1]
This commit replaces distutils.StrictVersion with
the Version class from the packaging egg.

[1] https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated

fixes https://github.com/Roadmaster/forcediphttpsadapter/issues/13